### PR TITLE
chore: fix oidc after github thumbprint changes

### DIFF
--- a/modules/github-oidc/main.tf
+++ b/modules/github-oidc/main.tf
@@ -4,9 +4,7 @@ resource "aws_iam_openid_connect_provider" "github" {
     "sts.amazonaws.com",
   ]
 
-  thumbprint_list = [
-    data.tls_certificate.token.certificates[0].sha1_fingerprint
-  ]
+  thumbprint_list = data.tls_certificate.token.certificates[*].sha1_fingerprint
 
   url = "https://token.actions.githubusercontent.com"
 


### PR DESCRIPTION
https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/ 

we need to have both fingerprints for the oidc after some changes 🤷‍♂️ 