### PR TITLE
chore: fix thumbprint list for github oidc

### DIFF
--- a/modules/github-oidc/main.tf
+++ b/modules/github-oidc/main.tf
@@ -4,7 +4,15 @@ resource "aws_iam_openid_connect_provider" "github" {
     "sts.amazonaws.com",
   ]
 
-  thumbprint_list = data.tls_certificate.token.certificates[*].sha1_fingerprint
+  thumbprint_list = distinct(
+    concat(
+      [
+        "6938fd4d98bab03faadb97b34396831e3780aea1",
+        "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+      ],
+      [for certificate in data.tls_certificate.token.certificates : certificate.sha1_fingerprint if certificate.is_ca]
+    )
+  )
 
   url = "https://token.actions.githubusercontent.com"
 
@@ -14,7 +22,7 @@ resource "aws_iam_openid_connect_provider" "github" {
 }
 
 data "tls_certificate" "token" {
-  url = "https://token.actions.githubusercontent.com/.well-known/jwks"
+  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
 }
 
 resource "aws_iam_role" "github_actions" {


### PR DESCRIPTION
previous fix is not working as the url will only provide one certificate and its random, you wont get all of them in one call. This hardcodes the ones that are used now and should catch if there are any new ones added so you can update it here. Not sure if there is a way to fully automate it as of right now :( 

https://github.com/aws-actions/configure-aws-credentials/issues/357#issuecomment-1610207576