### PR TITLE
feat: update pre-commit hooks and add no-commit-to-branch protection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: false
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.3
+    rev: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -17,17 +17,17 @@ repos:
           - --args=--skip-framework=cloudformation
 
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.21
+    rev: v0.1.30
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/cisagov/pre-commit-packer
-    rev: v0.0.2
+    rev: v0.3.1
     hooks:
       - id: packer_fmt
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -36,6 +36,7 @@ repos:
         exclude_types: [svg]
         args:
           - --markdown-linebreak-ext=md
+      - id: check-yaml
       - id: pretty-format-json
         args:
           - --autofix
@@ -46,6 +47,8 @@ repos:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
+      - id: no-commit-to-branch
+        args: ["--branch", "master", "--branch", "main"]
 
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
@@ -54,7 +57,7 @@ repos:
         args: ["-l", "-i", "2", "-ci", "-sr", "-w"]
 
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.22.0
+    rev: 0.36.1
     hooks:
       - id: check-github-actions
       - id: check-github-workflows

--- a/README.md
+++ b/README.md
@@ -27,17 +27,24 @@ pre-commit install
 
 The configuration is directly in [.pre-commit-config.yaml](.pre-commit-config.yaml) file. It mainly ensures the following:
 
-- terraform & shell code formatting
-- terraform docs generating
-- terraform validation
-- terraform linting for security compliance, etc.
-- avoids commiting merge-conflicts by mistake
-- convention for end-of-files (empty line at each of every file)
-- deletes trailing whitespaces at end of lines
-- pretty json & yaml formatting
-- avoids commiting private keys in git
-- avoids commiting large files in git
-- etc.
+- `terraform_fmt` - terraform code formatting
+- `terraform_docs` - auto-generated module documentation
+- `terraform_validate` - terraform syntax validation
+- `terraform_tflint` - terraform linting with custom rules
+- `terraform_checkov` - security and compliance scanning
+- `shellcheck` / `shfmt` - shell script linting and formatting
+- `packer_fmt` - packer file formatting
+- `check-merge-conflict` - avoids commiting merge-conflicts by mistake
+- `end-of-file-fixer` - convention for end-of-files (empty line at end of every file)
+- `trailing-whitespace` - deletes trailing whitespaces at end of lines
+- `check-yaml` - validates YAML syntax
+- `pretty-format-json` - consistent JSON formatting
+- `detect-private-key` - avoids commiting private keys in git
+- `check-added-large-files` - avoids commiting large files (>4MB) in git
+- `check-case-conflict` - catches filename case conflicts across platforms
+- `check-executables-have-shebangs` / `check-shebang-scripts-are-executable` - script permission sanity
+- `no-commit-to-branch` - prevents accidental direct commits to `master` and `main`
+- `check-github-actions` / `check-github-workflows` - validates GitHub Actions workflow schema
 
 It is possible to manually run all checks on all files using
 ```


### PR DESCRIPTION
## Summary
- Bump all pre-commit hook versions to latest
  - `antonbabenko/pre-commit-terraform` v1.77.3 -> v1.105.0
  - `gruntwork-io/pre-commit` v0.1.21 -> v0.1.30
  - `cisagov/pre-commit-packer` v0.0.2 -> v0.3.1
  - `pre-commit/pre-commit-hooks` v4.4.0 -> v6.0.0
  - `sirosen/check-jsonschema` 0.22.0 -> 0.36.1
- Add `no-commit-to-branch` hook preventing direct commits to `master` and `main`
- Add `check-yaml` hook for YAML syntax validation
- Update README pre-commit section with full list of all hooks and their descriptions

## Test plan
- [x] `pre-commit` passes on the staged files
- [x] `no-commit-to-branch` correctly blocks commits on `master`
- [x] CI pre-commit workflow passes