### PR TITLE
feat: update CI tool versions and pin terraform-destroy digest

### DIFF
--- a/.github/workflows/periodic-terraform-apply-05.yaml
+++ b/.github/workflows/periodic-terraform-apply-05.yaml
@@ -38,6 +38,6 @@ jobs:
           auto_approve: true
 
       - name: Terraform destroy
-        uses: dflook/terraform-destroy@main
+        uses: dflook/terraform-destroy@b198834c4a4dd959f26649f2a9d24c59e9c9f205 # v2
         with:
           path: examples/05-aws-complete

--- a/.github/workflows/periodic-terraform-apply-06.yaml
+++ b/.github/workflows/periodic-terraform-apply-06.yaml
@@ -38,6 +38,6 @@ jobs:
           auto_approve: true
 
       - name: Terraform destroy
-        uses: dflook/terraform-destroy@main
+        uses: dflook/terraform-destroy@b198834c4a4dd959f26649f2a9d24c59e9c9f205 # v2
         with:
           path: examples/06-minimal-aws-terraform-bootstrap

--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -21,32 +21,32 @@ jobs:
           sudo apt install -y python3 python3-pip curl unzip
           # tflint
           curl -sSLo ./tflint.zip \
-            https://github.com/terraform-linters/tflint/releases/download/v0.41.0/tflint_linux_amd64.zip
+            https://github.com/terraform-linters/tflint/releases/download/v0.60.0/tflint_linux_amd64.zip
           unzip ./tflint.zip
           chmod +x ./tflint
           sudo mv tflint /usr/local/bin/tflint
 
           # terraform
           curl -sSLo ./terraform.zip \
-            https://releases.hashicorp.com/terraform/1.1.6/terraform_1.1.6_linux_amd64.zip
+            https://releases.hashicorp.com/terraform/1.14.4/terraform_1.14.4_linux_amd64.zip
           sudo unzip -o ./terraform.zip -d /usr/local/bin/
           sudo chmod +x /usr/local/bin/terraform
 
           # terraform-docs
           curl -sSLo ./terraform-docs.tar.gz \
-            https://terraform-docs.io/dl/v0.15.0/terraform-docs-v0.15.0-$(uname)-amd64.tar.gz
+            https://terraform-docs.io/dl/v0.21.0/terraform-docs-v0.21.0-$(uname)-amd64.tar.gz
           tar -xzf ./terraform-docs.tar.gz
           chmod +x ./terraform-docs
           sudo mv ./terraform-docs /usr/local/bin/terraform-docs
 
           # shfmt
           curl -sSLo ./shfmt \
-            https://github.com/mvdan/sh/releases/download/v3.4.0/shfmt_v3.4.0_linux_amd64
+            https://github.com/mvdan/sh/releases/download/v3.12.0/shfmt_v3.12.0_linux_amd64
           chmod +x ./shfmt
           sudo mv ./shfmt /usr/local/bin/shfmt
 
           pip install pre-commit
-          pip install checkov==2.3.148
+          pip install checkov==3.2.500
 
 
       - name: pre-commit run

--- a/.github/workflows/terraform-apply-05.yaml
+++ b/.github/workflows/terraform-apply-05.yaml
@@ -48,6 +48,6 @@ jobs:
           retention-days: 30
 
       - name: Terraform destroy
-        uses: dflook/terraform-destroy@main
+        uses: dflook/terraform-destroy@b198834c4a4dd959f26649f2a9d24c59e9c9f205 # v2
         with:
           path: examples/05-aws-complete

--- a/.github/workflows/terraform-apply-06.yaml
+++ b/.github/workflows/terraform-apply-06.yaml
@@ -40,6 +40,6 @@ jobs:
           path: examples/06-minimal-aws-terraform-bootstrap
 
       - name: Terraform destroy
-        uses: dflook/terraform-destroy@main
+        uses: dflook/terraform-destroy@b198834c4a4dd959f26649f2a9d24c59e9c9f205 # v2
         with:
           path: examples/06-minimal-aws-terraform-bootstrap

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ There are several GitHub Actions workflows:
 - `terraform-apply-*.yaml` - to `terraform apply` all approved plans from PRs (approved == merged PR)
 - `periodic-terraform-apply-*.yaml` - aka "poor man's gitops" to periodically terraform apply what is in the default branch, can be also triggered manually (useful when terraform-apply workflows fail for issues with previous terraform plans, etc.)
 
+All GitHub Actions are pinned to full commit digests (not tags) for supply chain security. Tool versions in CI workflows are explicitly pinned for reproducibility.
+
 ## tflint
 
 ## checkov


### PR DESCRIPTION
## Summary
- Bump tool versions in `precommit.yaml` CI workflow:
  - terraform 1.1.6 -> 1.14.4
  - tflint v0.41.0 -> v0.60.0
  - terraform-docs v0.15.0 -> v0.21.0
  - shfmt v3.4.0 -> v3.12.0
  - checkov 2.3.148 -> 3.2.500
- Pin `dflook/terraform-destroy` to commit digest in all 4 workflows that used `@main` (supply chain security)
- Add README note about digest pinning and version pinning in CI

## Test plan
- [ ] CI pre-commit workflow passes with new tool versions
- [ ] Verify checkov 3.x CLI is compatible with existing `--quiet` and `--skip-framework` flags