### PR TITLE
feat: enhanced renovate config with grouping, automerge and EKS version tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,14 @@ We use renovate to manage all our dependencies.
 Since we prefer pinning our dependencies to certain versions (as opposed to using something like `:latest`, etc.), we still need an "upgrade strategy". Instead of manually checking for newer versions, changelogs and creating PRs to upgrade each of the dependencies, we have this automated.
 That's where renovate comes into play.
 
-Renovate is configured by [`renovate.json`](./renovate.json), the configuration we use is rather simple.
+Renovate is configured by [`renovate.json`](./renovate.json). Key features of our configuration:
+
+- **GitHub Action digest pinning** for supply chain security
+- **Grouped PRs** - Terraform providers and modules are grouped to reduce PR noise
+- **Automerge** for low-risk updates (provider patch versions, action digest updates)
+- **Custom regex managers** for tracking EKS/Kubernetes versions in Terraform variables
+- **Lock file maintenance** scheduled weekly to keep dependency metadata fresh
+- **Separate major/minor/patch** updates so breaking changes are clearly visible
 
 Renovate scans all files in default branch and looks for dependencies and their versions. It looks through terraform files, Dockerfiles, etc. and when it finds a new version is available for something, it creates a Pull Request with bumping the version, dumps Changelog, etc.
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,68 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    ":separateMajorMinorPatchUpdates"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 8am on monday"
+    ]
+  },
+  "packageRules": [
+    {
+      "description": "Group Terraform provider updates together",
+      "matchDatasources": [
+        "terraform-provider"
+      ],
+      "groupName": "terraform providers"
+    },
+    {
+      "description": "Group Terraform module updates together",
+      "matchDatasources": [
+        "terraform-module"
+      ],
+      "groupName": "terraform modules"
+    },
+    {
+      "description": "Automerge patch-level updates for Terraform providers",
+      "matchDatasources": [
+        "terraform-provider"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Automerge GitHub Actions digest updates",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "automerge": true
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "Track EKS Kubernetes version in Terraform variables",
+      "customType": "regex",
+      "fileMatch": [
+        "\\.tf$"
+      ],
+      "matchStrings": [
+        "k8s_version\\s*=\\s*\"(?<currentValue>[0-9]+\\.[0-9]+)\""
+      ],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+)\\.\\d+$"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Upgrade `renovate.json` from minimal to production-grade config:
  - Group Terraform provider updates into single PRs
  - Group Terraform module updates into single PRs
  - Automerge patch-level provider updates and GitHub Actions digest updates
  - Separate major/minor/patch updates for clear visibility of breaking changes
  - Weekly lock file maintenance schedule
  - `dependencies` label on all PRs
  - Custom regex manager to track EKS Kubernetes version (`k8s_version` in .tf files) against kubernetes/kubernetes releases
- Update README renovate section with details about the configuration features

## Test plan
- [ ] Renovate picks up the new config and creates grouped PRs
- [ ] Custom regex manager detects `k8s_version = "1.27"` in `examples/05-aws-complete/eks.tf`