### PR TITLE
feat: add terraform-lock workflow to auto-update lock files in PRs

### DIFF
--- a/.github/workflows/terraform-lock.yaml
+++ b/.github/workflows/terraform-lock.yaml
@@ -1,0 +1,72 @@
+---
+name: terraform-lock
+
+permissions:
+  contents: write
+  pull-requests: read
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+    paths:
+      - "**/versions.tf"
+      - "**/.terraform.lock.hcl"
+      - "renovate.json"
+
+jobs:
+  terraform-lock:
+    runs-on: ubuntu-latest
+    name: Update Terraform lock files
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Check if commit is from bot
+        id: check-bot
+        run: |
+          if [[ "${{ github.event.pull_request.user.login }}" == "renovate[bot]" ]] || \
+             [[ "${{ github.actor }}" == "github-actions[bot]" ]]; then
+            echo "is_bot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_bot=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269571bd # v3
+        with:
+          terraform_wrapper: false
+
+      - name: Update lock files
+        run: |
+          LOCK_PLATFORMS="-platform=windows_amd64 -platform=darwin_amd64 -platform=linux_amd64 -platform=darwin_arm64 -platform=linux_arm64"
+
+          # Find all directories containing .terraform.lock.hcl
+          for lockfile in $(find . -name ".terraform.lock.hcl" -type f | sort); do
+            dir=$(dirname "$lockfile")
+            echo "Updating lock file in $dir"
+            cd "$dir"
+            terraform init -backend=false -upgrade
+            terraform providers lock $LOCK_PLATFORMS
+            cd - > /dev/null
+          done
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --quiet -- '**/.terraform.lock.hcl' || echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push changes
+        if: steps.git-check.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add '**/.terraform.lock.hcl'
+          git commit -m "chore: update terraform lock files for all platforms"
+          git push

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ terraform providers lock  \
   -platform=linux_arm64
 ```
 
+The `terraform-lock.yaml` workflow automatically updates lock files when provider versions change in PRs. It runs `terraform providers lock` for all platforms and commits the updated lock files back to the PR branch.
+
 ## renovate
 We use renovate to manage all our dependencies.
 
@@ -101,7 +103,7 @@ Renovate scans all files in default branch and looks for dependencies and their 
 
 We run all github actions checks to validate, test and `terraform plan` the changes and when it is safe to upgrade, we simply merge the PR.
 
-Note: one additional github action runs to `terraform lock` to sync the terraform lockfile, since renovate doesn't seem do this.
+The `terraform-lock.yaml` workflow automatically updates lock files when Renovate (or any PR) changes provider versions, since Renovate doesn't handle this natively.
 
 ## .gitignore
 This `.gitignore` is a template we use in all our git repos where terraform is used.
@@ -114,6 +116,7 @@ There are several GitHub Actions workflows:
 - `terraform-plan-*.yaml` - to `terraform plan` all folders in PRs
 - `terraform-apply-*.yaml` - to `terraform apply` all approved plans from PRs (approved == merged PR)
 - `periodic-terraform-apply-*.yaml` - aka "poor man's gitops" to periodically terraform apply what is in the default branch, can be also triggered manually (useful when terraform-apply workflows fail for issues with previous terraform plans, etc.)
+- `terraform-lock.yaml` - automatically updates `.terraform.lock.hcl` files for all platforms when provider versions change in PRs
 
 All GitHub Actions are pinned to full commit digests (not tags) for supply chain security. Tool versions in CI workflows are explicitly pinned for reproducibility.
 


### PR DESCRIPTION
## Summary
- Add `terraform-lock.yaml` workflow that automatically updates `.terraform.lock.hcl` files for all platforms when provider versions change in PRs
- Triggers on changes to `versions.tf`, `.terraform.lock.hcl`, or `renovate.json`
- Runs `terraform providers lock` for windows_amd64, darwin_amd64, linux_amd64, darwin_arm64, linux_arm64
- Commits updated lock files back to the PR branch
- Updates README.md with workflow documentation

## Test plan
- [ ] Open a PR that changes a provider version in `versions.tf`
- [ ] Verify the workflow runs and commits updated lock files