### PR TITLE
fix: update renovate config from deprecated config:base to config:recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     "helpers:pinGitHubActionDigests",
     ":separateMajorMinorPatchUpdates"
   ],


### PR DESCRIPTION
## Summary

- Replace deprecated `config:base` with `config:recommended` in renovate.json

This fixes the Renovate configuration error that was blocking PRs.