### PR TITLE
feat: add Packer build workflow for custom AMI builds

### DIFF
--- a/.github/workflows/packer-build.yaml
+++ b/.github/workflows/packer-build.yaml
@@ -1,0 +1,90 @@
+---
+name: packer-build
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: 'Name of the AMI build'
+        required: true
+        type: string
+      packer_directory:
+        description: 'Directory containing Packer files'
+        required: true
+        type: string
+      pkvars_file:
+        description: 'Packer variables file'
+        required: true
+        type: string
+      pkr_file:
+        description: 'Packer template file'
+        required: true
+        type: string
+      aws_region:
+        description: 'AWS region for the build'
+        required: false
+        type: string
+        default: 'eu-west-1'
+    secrets:
+      OIDC_ROLE_ARN:
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build ${{ inputs.name }}
+
+    steps:
+      - name: Check if triggered by bot
+        id: check-bot
+        run: |
+          if [[ "${{ github.event.head_commit.author.name }}" == "github-actions[bot]" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping build - triggered by bot commit"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.check-bot.outputs.skip != 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Configure AWS credentials
+        if: steps.check-bot.outputs.skip != 'true'
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
+          role-session-name: GithubActionsPackerBuild
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Setup Packer
+        if: steps.check-bot.outputs.skip != 'true'
+        uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75571a # v3
+
+      - name: Packer Init
+        if: steps.check-bot.outputs.skip != 'true'
+        working-directory: ${{ inputs.packer_directory }}
+        run: packer init ${{ inputs.pkr_file }}
+
+      - name: Packer Validate
+        if: steps.check-bot.outputs.skip != 'true'
+        working-directory: ${{ inputs.packer_directory }}
+        run: packer validate -var-file=${{ inputs.pkvars_file }} ${{ inputs.pkr_file }}
+
+      - name: Packer Build
+        if: steps.check-bot.outputs.skip != 'true'
+        working-directory: ${{ inputs.packer_directory }}
+        run: |
+          packer build -var-file=${{ inputs.pkvars_file }} ${{ inputs.pkr_file }} | tee build_output.txt
+
+          AMI_ID=$(grep -oP 'ami-[a-z0-9]+' build_output.txt | tail -1)
+          echo "AMI_ID=$AMI_ID" >> "$GITHUB_ENV"
+
+          echo "## Packer Build: ${{ inputs.name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**AMI ID:** \`$AMI_ID\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Region:** ${{ inputs.aws_region }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/packer-wireguard-04.yaml
+++ b/.github/workflows/packer-wireguard-04.yaml
@@ -1,0 +1,63 @@
+---
+name: packer-wireguard-04
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'examples/04-aws-wireguard-vpn/packer/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'examples/04-aws-wireguard-vpn/packer/**'
+  workflow_dispatch:
+
+concurrency:
+  group: packer-wireguard-04-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    name: Validate Packer
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
+          role-session-name: GithubActionsPackerValidate
+          aws-region: eu-west-1
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75571a # v3
+
+      - name: Packer Init
+        working-directory: examples/04-aws-wireguard-vpn/packer
+        run: packer init wireguard.pkr.hcl
+
+      - name: Packer Validate
+        working-directory: examples/04-aws-wireguard-vpn/packer
+        run: packer validate -var-file=wireguard-prod.pkvars.hcl wireguard.pkr.hcl
+
+  build:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/packer-build.yaml
+    with:
+      name: wireguard-04
+      packer_directory: examples/04-aws-wireguard-vpn/packer
+      pkvars_file: wireguard-prod.pkvars.hcl
+      pkr_file: wireguard.pkr.hcl
+      aws_region: eu-west-1
+    secrets:
+      OIDC_ROLE_ARN: ${{ secrets.OIDC_ROLE_ARN }}

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ There are several GitHub Actions workflows:
 - `terraform-lock.yaml` - automatically updates `.terraform.lock.hcl` files for all platforms when provider versions change in PRs
 - `terraform-state-unlock.yaml` - scheduled workflow (daily 2 AM) that detects and removes stale S3 state locks (>4 hours old), also supports manual unlock via workflow_dispatch
 - `terraform-drift-detection.yaml` - scheduled workflow (twice daily at 8 AM and 4 PM UTC) that runs `terraform plan` on all environments to detect configuration drift
+- `packer-build.yaml` - reusable workflow for building AMIs with Packer
+- `packer-wireguard-04.yaml` - builds WireGuard VPN AMI when Packer files change in example 04
 
 All GitHub Actions are pinned to full commit digests (not tags) for supply chain security.
 
@@ -136,6 +138,18 @@ The workflow uses `terraform plan -detailed-exitcode` where exit code 2 indicate
 3. The issue links to the workflow run for detailed plan output
 
 The workflow can also be triggered manually via `workflow_dispatch` for on-demand drift checks. Tool versions in CI workflows are explicitly pinned for reproducibility.
+
+### Packer Builds
+
+The `packer-build.yaml` is a reusable workflow for building custom AMIs with Packer. It provides:
+
+- **OIDC authentication** for secure AWS access
+- **Validation on PRs** - runs `packer validate` to catch errors before merge
+- **Build on merge** - builds the AMI when changes are pushed to master
+- **Bot commit detection** - skips builds triggered by automated commits to prevent loops
+- **Step summary** - outputs the built AMI ID to GitHub Actions summary
+
+Example 04 (WireGuard VPN) uses this pattern via `packer-wireguard-04.yaml`. To add Packer CI for other examples, create a caller workflow that references the reusable workflow with appropriate inputs.
 
 ## tflint
 


### PR DESCRIPTION
## Summary

- Add reusable `packer-build.yaml` workflow for building AMIs with Packer
- Add `packer-wireguard-04.yaml` caller workflow for WireGuard VPN example
- Validates Packer templates on PRs, builds AMIs on merge to master
- Uses OIDC auth, bot commit detection to prevent loops, step summary output

## Test plan

- [ ] Verify packer validate runs on PR changes to `examples/04-aws-wireguard-vpn/packer/`
- [ ] Verify packer build runs on merge to master
- [ ] Test manual workflow_dispatch trigger