### PR TITLE
fix: remove invalid renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests",
-    ":separateMajorMinorPatchUpdates"
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
## Summary
- Remove non-existent `:separateMajorMinorPatchUpdates` preset that was causing Renovate config validation errors
- `config:recommended` already includes `:separateMajorReleases` by default, so major/minor separation still works

## Test plan
- [ ] Verify Renovate no longer reports config errors
- [ ] Verify Renovate continues creating dependency update PRs