### PR TITLE
fix: correct hashicorp/setup-terraform SHA pins in workflows

### DIFF
--- a/.github/workflows/terraform-drift-detection.yaml
+++ b/.github/workflows/terraform-drift-detection.yaml
@@ -30,7 +30,7 @@ jobs:
           aws-region: eu-west-1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555b616edd9a2a4c67 # v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_wrapper: false
 

--- a/.github/workflows/terraform-lock.yaml
+++ b/.github/workflows/terraform-lock.yaml
@@ -39,7 +39,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269571bd # v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_wrapper: false
 


### PR DESCRIPTION
## Summary
- Fixed incorrect SHA pins for `hashicorp/setup-terraform@v3` in both `terraform-lock.yaml` and `terraform-drift-detection.yaml` workflows
- The previous SHAs were invalid/non-existent, causing workflow failures with `An action could not be found at the URI` error

## Test plan
- [ ] Verify `terraform-lock` workflow runs successfully on a PR that modifies `versions.tf`
- [ ] Verify `terraform-drift-detection` workflow runs successfully via manual dispatch