### PR TITLE
feat: add scheduled scale-in/scale-out workflow examples

### DIFF
--- a/.github/workflows/scheduled-scale-in.yaml.example
+++ b/.github/workflows/scheduled-scale-in.yaml.example
@@ -1,0 +1,43 @@
+---
+name: scheduled-scale-in
+
+permissions:
+  id-token: write      # for fetching the OIDC token
+  contents: read       # for actions/checkout
+  pull-requests: write # For dflook comments on PR
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Scale down non-production resources on Friday evening (18:00 UTC)
+    - cron: "0 18 * * 5"
+
+jobs:
+  tf-apply:
+    runs-on: ubuntu-latest
+    name: Scale in - reduce non-prod resources
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: master
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
+        with:
+          role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
+          role-session-name: GithubActionsTerraform
+          aws-region: eu-west-1
+
+      - name: Terraform apply - scale in Aurora readers
+        uses: dflook/terraform-apply@5489b988934a50bf1489d5b7c5253b46520a7dca # v2
+        with:
+          path: examples/05-aws-complete
+          auto_approve: true
+          target: |
+            module.db.aws_appautoscaling_target.this
+          variables: |
+            db_min_replica_count=0

--- a/.github/workflows/scheduled-scale-out.yaml.example
+++ b/.github/workflows/scheduled-scale-out.yaml.example
@@ -1,0 +1,43 @@
+---
+name: scheduled-scale-out
+
+permissions:
+  id-token: write      # for fetching the OIDC token
+  contents: read       # for actions/checkout
+  pull-requests: write # For dflook comments on PR
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Scale up non-production resources on Monday morning (06:00 UTC)
+    - cron: "0 6 * * 1"
+
+jobs:
+  tf-apply:
+    runs-on: ubuntu-latest
+    name: Scale out - restore non-prod resources
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: master
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
+        with:
+          role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
+          role-session-name: GithubActionsTerraform
+          aws-region: eu-west-1
+
+      - name: Terraform apply - scale out Aurora readers
+        uses: dflook/terraform-apply@5489b988934a50bf1489d5b7c5253b46520a7dca # v2
+        with:
+          path: examples/05-aws-complete
+          auto_approve: true
+          target: |
+            module.db.aws_appautoscaling_target.this
+          variables: |
+            db_min_replica_count=2

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ There are several GitHub Actions workflows:
 - `packer-build.yaml` - reusable workflow for building AMIs with Packer
 - `packer-wireguard-04.yaml` - builds WireGuard VPN AMI when Packer files change in example 04
 - `update-bottlerocket-ami.yaml` - weekly check for new Bottlerocket AMI releases, creates a PR to update the pinned version
+- `scheduled-scale-in.yaml.example` / `scheduled-scale-out.yaml.example` - example workflows for scaling down non-prod resources on evenings/weekends and scaling back up on Monday morning
 
 All GitHub Actions are pinned to full commit digests (not tags) for supply chain security.
 
@@ -151,6 +152,10 @@ The `packer-build.yaml` is a reusable workflow for building custom AMIs with Pac
 - **Step summary** - outputs the built AMI ID to GitHub Actions summary
 
 Example 04 (WireGuard VPN) uses this pattern via `packer-wireguard-04.yaml`. To add Packer CI for other examples, create a caller workflow that references the reusable workflow with appropriate inputs.
+
+### Scheduled Scale-In / Scale-Out
+
+The `scheduled-scale-in.yaml.example` and `scheduled-scale-out.yaml.example` workflows demonstrate how to reduce non-production costs by scaling down resources on evenings/weekends and scaling back up before business hours. They use targeted `terraform apply` with variable overrides to adjust Aurora reader replica counts (or any other autoscaling target) on a cron schedule. Copy and customize for your environments.
 
 ### Bottlerocket AMI Updates
 


### PR DESCRIPTION
## Summary
- Add example GitHub Actions workflows for scaling down non-production resources on evenings/weekends and scaling back up before business hours
- `scheduled-scale-in.yaml.example` scales down Aurora readers on Friday evening (18:00 UTC)
- `scheduled-scale-out.yaml.example` scales up Aurora readers on Monday morning (06:00 UTC)
- Uses targeted `terraform apply` with variable overrides
- Update README with documentation

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Confirm action SHAs match existing workflows in the repo
- [ ] Review cron schedules make sense for intended use case