### PR TITLE
feat: add Lambda deployment workflow with reproducible packaging

### DIFF
--- a/.github/workflows/lambda-deploy.yaml
+++ b/.github/workflows/lambda-deploy.yaml
@@ -1,0 +1,94 @@
+---
+name: lambda-deploy
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      lambda_name:
+        description: 'Lambda function name (directory name in src/)'
+        required: true
+        type: string
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - stage
+          - prod
+      s3_bucket:
+        description: 'S3 bucket for Lambda artifacts'
+        required: true
+        type: string
+      aws_region:
+        description: 'AWS region'
+        required: false
+        type: string
+        default: 'eu-west-1'
+      update_function:
+        description: 'Update Lambda function code after upload'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy ${{ inputs.lambda_name }} to ${{ inputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: '22'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
+        with:
+          role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
+          role-session-name: GithubActionsLambdaDeploy
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Package Lambda
+        run: |
+          chmod +x scripts/package-lambdas.sh
+          ./scripts/package-lambdas.sh "${{ inputs.lambda_name }}"
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp "src/${{ inputs.lambda_name }}.zip" \
+            "s3://${{ inputs.s3_bucket }}/${{ inputs.environment }}/${{ inputs.lambda_name }}.zip"
+          echo "Uploaded to s3://${{ inputs.s3_bucket }}/${{ inputs.environment }}/${{ inputs.lambda_name }}.zip"
+
+      - name: Update Lambda function code
+        if: inputs.update_function
+        run: |
+          FUNCTION_NAME="${{ inputs.environment }}-${{ inputs.lambda_name }}"
+          if aws lambda get-function --function-name "$FUNCTION_NAME" --region "${{ inputs.aws_region }}" > /dev/null 2>&1; then
+            aws lambda update-function-code \
+              --function-name "$FUNCTION_NAME" \
+              --s3-bucket "${{ inputs.s3_bucket }}" \
+              --s3-key "${{ inputs.environment }}/${{ inputs.lambda_name }}.zip" \
+              --region "${{ inputs.aws_region }}" \
+              --publish
+            echo "Updated Lambda function: $FUNCTION_NAME"
+          else
+            echo "::warning::Lambda function '$FUNCTION_NAME' does not exist yet - run terraform apply first"
+          fi
+
+      - name: Summary
+        run: |
+          echo "## Lambda Deployment Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Parameter | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Lambda | \`${{ inputs.lambda_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Environment | \`${{ inputs.environment }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| S3 Bucket | \`${{ inputs.s3_bucket }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Region | \`${{ inputs.aws_region }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Function Updated | \`${{ inputs.update_function }}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/package-lambdas.yaml
+++ b/.github/workflows/package-lambdas.yaml
@@ -1,0 +1,80 @@
+---
+name: Package Lambda Functions
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request:
+    paths:
+      - 'src/*/*.mjs'
+      - 'src/*/*.js'
+      - 'src/*/package.json'
+      - 'scripts/package-lambdas.sh'
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    name: Package Lambda Functions
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: '22'
+
+      - name: Detect changed lambdas
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: changes
+        with:
+          filters: |
+            packaging-script:
+              - 'scripts/package-lambdas.sh'
+            src:
+              - 'src/**'
+
+      - name: Determine lambdas to package
+        id: lambdas
+        run: |
+          if [ "${{ steps.changes.outputs.packaging-script }}" == "true" ]; then
+            echo "Package all lambdas (packaging script changed)"
+            echo "args=" >> "$GITHUB_OUTPUT"
+          else
+            CHANGED=""
+            for dir in src/*/; do
+              lambda_name=$(basename "$dir")
+              if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^src/${lambda_name}/"; then
+                CHANGED="$CHANGED $lambda_name"
+              fi
+            done
+            echo "args=$CHANGED" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package Lambda functions
+        if: steps.changes.outputs.src == 'true' || steps.changes.outputs.packaging-script == 'true'
+        run: |
+          chmod +x scripts/package-lambdas.sh
+          ./scripts/package-lambdas.sh ${{ steps.lambdas.outputs.args }}
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code src/*.zip || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push updated packages
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add src/*.zip
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: update Lambda function packages"
+            git push
+          fi

--- a/scripts/package-lambdas.sh
+++ b/scripts/package-lambdas.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SRC_DIR="${PROJECT_ROOT}/src"
+
+package_lambda() {
+  local lambda_name=$1
+  local lambda_dir="${SRC_DIR}/${lambda_name}"
+  local output_zip="${SRC_DIR}/${lambda_name}.zip"
+
+  if [ ! -d "${lambda_dir}" ]; then
+    echo "Error: Lambda directory ${lambda_dir} does not exist"
+    return 1
+  fi
+
+  echo "Packaging ${lambda_name}..."
+
+  if [ -f "${output_zip}" ]; then
+    rm -f "${output_zip}"
+  fi
+
+  cd "${lambda_dir}"
+
+  # Install npm dependencies if package.json exists
+  if [ -f "package.json" ]; then
+    echo "  - Installing npm dependencies..."
+    npm ci --omit=dev --quiet
+  fi
+
+  # Normalize timestamps to make zip reproducible (same content = identical zip)
+  find . -exec touch -t 202001010000.00 {} +
+  # Sort files to ensure deterministic ordering in zip
+  find . -type f | LC_ALL=C sort | zip -X -q "${output_zip}" -@
+
+  local size
+  size=$(du -h "${output_zip}" | cut -f1)
+  echo "  Created ${lambda_name}.zip (${size})"
+
+  cd "${PROJECT_ROOT}"
+}
+
+if [ ! -d "${SRC_DIR}" ]; then
+  echo "No src/ directory found, nothing to package"
+  exit 0
+fi
+
+if [ $# -gt 0 ]; then
+  for lambda_name in "$@"; do
+    package_lambda "$lambda_name"
+  done
+else
+  # Auto-discover all Lambda directories (any directory in src/ with index.mjs or index.js)
+  found=false
+  for lambda_dir in "${SRC_DIR}"/*/; do
+    if [ -f "${lambda_dir}/index.mjs" ] || [ -f "${lambda_dir}/index.js" ]; then
+      lambda_name=$(basename "${lambda_dir}")
+      package_lambda "$lambda_name"
+      found=true
+    fi
+  done
+
+  if [ "$found" = false ]; then
+    echo "No Lambda functions found in src/"
+  fi
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/package-lambdas.sh` for reproducible Lambda packaging (normalized timestamps, deterministic zip ordering, auto-discovery of Lambda directories in `src/`)
- Add `package-lambdas.yaml` workflow that auto-packages Lambda functions on PRs when source code changes and commits the updated zip files back to the branch
- Add `lambda-deploy.yaml` manual workflow dispatch for deploying Lambda functions to S3 and optionally updating the function code via AWS CLI
- Document Lambda deployment pattern in README

## Test plan
- [ ] Verify `scripts/package-lambdas.sh` runs locally when `src/` lambdas exist
- [ ] Verify `package-lambdas.yaml` triggers on PR changes to `src/` paths
- [ ] Verify `lambda-deploy.yaml` can be dispatched manually with correct inputs
- [ ] Verify pre-commit passes